### PR TITLE
Add Canada region

### DIFF
--- a/scripts/localize.py
+++ b/scripts/localize.py
@@ -24,7 +24,7 @@ LISTS = ROOT / "lists"
 DEFAULT_OUT_ROOT = ROOT / "lists-regions"
 
 # Labels observed in the audit; extend when src/ gains new region-prefixed entries.
-SOURCE_REGION_LABELS = ("de", "us")
+SOURCE_REGION_LABELS = ("de", "us", "ca")
 REGION_RE = re.compile(r"^[a-z]{2}$")
 EXPECTED_FILES = (
     "safe-adblock.txt",

--- a/src/safe.txt
+++ b/src/safe.txt
@@ -25,3 +25,4 @@ us.lgtvsdp.com # SAFE: SDP telemetry, region endpoint
 lgtvsdp.com # SAFE: SDP telemetry apex (service delivery platform beacons)
 initscr.lge.com # SAFE: initial-setup telemetry (boot-time only)
 info.lgsmartad.com # SAFE: ad info endpoint (admanager poll ~60s); community report: Level1Techs "LG TV Block Mini-How-to" #255178 (wendell, 2026-09-05; observed live on G5); not observed on G1
+ca.nextlgsdp.com # SAFE: SDP region endpoint, telemetry


### PR DESCRIPTION
Two changes:
- Add "ca" region label to scripts/localize.py.
- Add Canadian regional telemetry endpoint to src/safe.txt.

Tests run locally:
```
python3 scripts/build.py check && python3 scripts/test_build.py
check OK: safe=20 strict=61 zone-anchors=9 outputs=6
source files: ['safe.txt', 'strict.txt', 'zones.txt']
..................
----------------------------------------------------------------------
Ran 18 tests in 0.002s

OK
```
Continuous DNS requests to ca.nextlgsdp.com observed about every minute after power on and Plex playing local content, log attached [querylog.json](https://github.com/user-attachments/files/32152907/querylog.json).
TV model is LG C1, located in Canada.